### PR TITLE
Notify immediately feature

### DIFF
--- a/connectify/src/main/java/com/zplesac/connectifty/Connectify.java
+++ b/connectify/src/main/java/com/zplesac/connectifty/Connectify.java
@@ -69,19 +69,39 @@ public class Connectify {
     }
 
     /**
-     * Register for connectivity events. Must be called separately for each activity/context.
+     * Register for network connectivity events. Must be called separately for each activity/context, and will use
+     * global configuration to determine if we should notify the callback immediately about current network connection
+     * state.
+     *
+     * @param object   Object which is registered to network change receiver.
+     * @param listener Callback listener.
      */
     public void registerForConnectivityEvents(Object object, ConnectivityChangeListener listener) {
+        registerForConnectivityEvents(object, configuration.isNotifyImmediately(), listener);
+    }
+
+    /**
+     * Register for network connectivity events. Must be called separately for each activity/context.
+     *
+     * @param object            Object which is registered to network change receiver.
+     * @param notifyImmediately Indicates should we immediately notify the callback about current network connection state.
+     * @param listener          Callback listener.
+     */
+    public void registerForConnectivityEvents(Object object, boolean notifyImmediately, ConnectivityChangeListener listener) {
         boolean hasConnection = hasNetworkConnection();
 
         if (ConnectifyCache.isLastNetworkStateStored(object)
                 && ConnectifyCache.getLastNetworkState(object) != hasConnection) {
             ConnectifyCache.setLastNetworkState(object, hasConnection);
 
-            notifyConnectionChange(hasConnection, listener);
+            if (notifyImmediately) {
+                notifyConnectionChange(hasConnection, listener);
+            }
         } else if (!ConnectifyCache.isLastNetworkStateStored(object)) {
             ConnectifyCache.setLastNetworkState(object, hasConnection);
-            notifyConnectionChange(hasConnection, listener);
+            if (notifyImmediately) {
+                notifyConnectionChange(hasConnection, listener);
+            }
         }
 
         IntentFilter filter = new IntentFilter();

--- a/connectify/src/main/java/com/zplesac/connectifty/ConnectifyConfiguration.java
+++ b/connectify/src/main/java/com/zplesac/connectifty/ConnectifyConfiguration.java
@@ -88,7 +88,7 @@ public class ConnectifyConfiguration {
         private ConnectifyStrenght minimumlSignalStrength = ConnectifyStrenght.POOR;
 
         /**
-         * Boolean value which defines do want to notify the listener about current network connection state
+         * Boolean value which defines do we want to notify the listener about current network connection state
          * immediately after the listener has been registered.
          * Default is set to true.
          */

--- a/connectify/src/main/java/com/zplesac/connectifty/ConnectifyConfiguration.java
+++ b/connectify/src/main/java/com/zplesac/connectifty/ConnectifyConfiguration.java
@@ -25,6 +25,8 @@ public class ConnectifyConfiguration {
 
     private LruCache<String, Boolean> inMemoryCache;
 
+    private boolean notifyImmediately;
+
     private ConnectifyConfiguration(Builder builder) {
         this.context = builder.context;
         this.registeredForMobileNetworkChanges = builder.registerForMobileNetworkChanges;
@@ -32,6 +34,7 @@ public class ConnectifyConfiguration {
         this.minimumSignalStrength = builder.minimumlSignalStrength;
         this.cacheSize = builder.cacheSize;
         this.inMemoryCache = new LruCache<>(cacheSize);
+        this.notifyImmediately = builder.notifyImmediately;
     }
 
     public Context getContext() {
@@ -58,18 +61,22 @@ public class ConnectifyConfiguration {
         return inMemoryCache;
     }
 
+    public boolean isNotifyImmediately() {
+        return notifyImmediately;
+    }
+
     public static class Builder {
 
         private Context context;
 
         /**
-         * Bool value which defines should we register for WiFi network changes.
+         * Boolean value which defines should we register for WiFi network changes.
          * Default value is set to true.
          */
         private boolean registerForWiFiChanges = true;
 
         /**
-         * Bool value which defines should we register for mobile network changes.
+         * Boolean value which defines should we register for mobile network changes.
          * Default value is set to true.
          */
         private boolean registerForMobileNetworkChanges = true;
@@ -80,16 +87,27 @@ public class ConnectifyConfiguration {
          */
         private ConnectifyStrenght minimumlSignalStrength = ConnectifyStrenght.POOR;
 
+        /**
+         * Boolean value which defines do want to notify the listener about current network connection state
+         * immediately after the listener has been registered.
+         * Default is set to true.
+         */
+        private boolean notifyImmediately = true;
+
         private final int kbSize = 1024;
 
         private final int memoryPart = 10;
 
-        // Get max available VM memory, exceeding this amount will throw an
-        // OutOfMemory exception. Stored in kilobytes as LruCache takes an
-        // int in its constructor.
+        /**
+         * Get max available VM memory, exceeding this amount will throw an
+         * OutOfMemory exception. Stored in kilobytes as LruCache takes an
+         * int in its constructor.
+         */
         private final int maxMemory = (int) (Runtime.getRuntime().maxMemory() / kbSize);
 
-        // Use 1/10th of the available memory for this memory cache.
+        /**
+         * Use 1/10th of the available memory for this memory cache.
+         */
         private int cacheSize = maxMemory / memoryPart;
 
         public Builder(Context context) {
@@ -113,6 +131,11 @@ public class ConnectifyConfiguration {
 
         public Builder setCacheSize(int size) {
             this.cacheSize = size;
+            return this;
+        }
+
+        public Builder setNotifyImmediately(boolean shouldNotify) {
+            this.notifyImmediately = shouldNotify;
             return this;
         }
 

--- a/sampleapp/src/main/java/com/zplesac/connectify/sampleapp/SampleApp.java
+++ b/sampleapp/src/main/java/com/zplesac/connectify/sampleapp/SampleApp.java
@@ -14,7 +14,13 @@ public class SampleApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        ConnectifyConfiguration connectifyConfiguration = new ConnectifyConfiguration.Builder(this).build();
+
+        // Define global configuration. We'll customize the default behaviour by defining
+        // that we don't want to be notified about current network connection state after
+        // we register for network connectivity events.
+        ConnectifyConfiguration connectifyConfiguration = new ConnectifyConfiguration.Builder(this)
+                .setNotifyImmediately(false)
+                .build();
         Connectify.getInstance().init(connectifyConfiguration);
     }
 }

--- a/sampleapp/src/main/java/com/zplesac/connectify/sampleapp/activities/SimpleActivity.java
+++ b/sampleapp/src/main/java/com/zplesac/connectify/sampleapp/activities/SimpleActivity.java
@@ -35,6 +35,8 @@ public class SimpleActivity extends Activity implements ConnectivityChangeListen
     @Override
     protected void onStart() {
         super.onStart();
+        // Omit the default configuration - we want to obtain the current network connection state
+        // after we register for network connectivity events.
         Connectify.getInstance().registerForConnectivityEvents(this, true,  this);
     }
 

--- a/sampleapp/src/main/java/com/zplesac/connectify/sampleapp/activities/SimpleActivity.java
+++ b/sampleapp/src/main/java/com/zplesac/connectify/sampleapp/activities/SimpleActivity.java
@@ -35,7 +35,7 @@ public class SimpleActivity extends Activity implements ConnectivityChangeListen
     @Override
     protected void onStart() {
         super.onStart();
-        Connectify.getInstance().registerForConnectivityEvents(this, this);
+        Connectify.getInstance().registerForConnectivityEvents(this, true,  this);
     }
 
     @Override


### PR DESCRIPTION
Added nottifyImmediately configuration value, which defines do we want to be notified about network connection state immediately after the listener has been registered.
