### PR TITLE
Test network request

### DIFF
--- a/connectionbuddy/src/main/AndroidManifest.xml
+++ b/connectionbuddy/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.zplesac.connectionbuddy">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 

--- a/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddy.java
+++ b/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddy.java
@@ -29,6 +29,14 @@ import java.util.HashMap;
  */
 public class ConnectionBuddy {
 
+    private static final String HEADER_KEY_USER_AGENT = "User-Agent";
+
+    private static final String HEADER_VALUE_USER_AGENT = "Android";
+
+    private static final String HEADER_KEY_CONNECTION = "Connection";
+
+    private static final String HEADER_VALUE_CONNECTION = "close";
+
     private static final String ACTION_CONNECTIVITY_CHANGE = "android.net.conn.CONNECTIVITY_CHANGE";
 
     private static final String ACTION_WIFI_STATE_CHANGE = "android.net.wifi.WIFI_STATE_CHANGED";
@@ -168,7 +176,8 @@ public class ConnectionBuddy {
 
     /**
      * Determine if we should notify the listener about active internet connection, based on configuration values.
-     * @param event ConnectivityEvent which will be posted to listener.
+     *
+     * @param event    ConnectivityEvent which will be posted to listener.
      * @param listener ConnectivityChangeListener which will receive ConnectivityEvent.
      */
     private void handleActiveInternetConnection(ConnectivityEvent event, ConnectivityChangeListener listener) {
@@ -224,7 +233,7 @@ public class ConnectionBuddy {
         if (hasNetworkConnection()) {
             testNetworkRequest(listener);
         } else {
-            listener.onResponseObtained();
+            listener.onNoResponse();
         }
     }
 
@@ -242,8 +251,8 @@ public class ConnectionBuddy {
                 try {
                     HttpURLConnection httpURLConnection = (HttpURLConnection)
                             (new URL(NETWORK_CHECK_URL).openConnection());
-                    httpURLConnection.setRequestProperty("User-Agent", "Android");
-                    httpURLConnection.setRequestProperty("Connection", "close");
+                    httpURLConnection.setRequestProperty(HEADER_KEY_USER_AGENT, HEADER_VALUE_USER_AGENT);
+                    httpURLConnection.setRequestProperty(HEADER_KEY_CONNECTION, HEADER_VALUE_CONNECTION);
                     httpURLConnection.setConnectTimeout(CONNECTION_TIMEOUT);
                     httpURLConnection.connect();
 

--- a/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddy.java
+++ b/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddy.java
@@ -166,6 +166,11 @@ public class ConnectionBuddy {
         }
     }
 
+    /**
+     * Determine if we should notify the listener about active internet connection, based on configuration values.
+     * @param event ConnectivityEvent which will be posted to listener.
+     * @param listener ConnectivityChangeListener which will receive ConnectivityEvent.
+     */
     private void handleActiveInternetConnection(ConnectivityEvent event, ConnectivityChangeListener listener) {
         // check if signal strength is bellow minimum defined strength
         if (event.getStrength().ordinal() < configuration.getMinimumSignalStrength().ordinal()) {

--- a/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddyConfiguration.java
+++ b/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddyConfiguration.java
@@ -30,6 +30,8 @@ public class ConnectionBuddyConfiguration {
 
     private ConnectivityManager connectivityManager;
 
+    private boolean notifyOnlyReliableEvents;
+
     private ConnectionBuddyConfiguration(Builder builder) {
         this.context = builder.context;
         this.registeredForMobileNetworkChanges = builder.registerForMobileNetworkChanges;
@@ -38,6 +40,7 @@ public class ConnectionBuddyConfiguration {
         this.cacheSize = builder.cacheSize;
         this.inMemoryCache = new LruCache<>(cacheSize);
         this.notifyImmediately = builder.notifyImmediately;
+        this.notifyOnlyReliableEvents = builder.notifyOnlyReliableEvents;
         this.connectivityManager =  (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
     }
 
@@ -71,6 +74,10 @@ public class ConnectionBuddyConfiguration {
 
     public ConnectivityManager getConnectivityManager() {
         return connectivityManager;
+    }
+
+    public boolean isNotifyOnlyReliableEvents() {
+        return notifyOnlyReliableEvents;
     }
 
     public static class Builder {
@@ -114,6 +121,13 @@ public class ConnectionBuddyConfiguration {
         private boolean notifyImmediately = true;
 
         /**
+         * Boolean value which defines do we want to use reliable network events. This means that if we have active internet connection,
+         * it will try to execute test network request to determine if user is capable of any network operation.
+         * Default is set to false.
+         */
+        private boolean notifyOnlyReliableEvents = false;
+
+        /**
          * Use 1/10th of the available memory for this memory cache.
          */
         private int cacheSize = maxMemory / memoryPart;
@@ -146,6 +160,12 @@ public class ConnectionBuddyConfiguration {
             this.notifyImmediately = shouldNotify;
             return this;
         }
+
+        public Builder notifyOnlyReliableEvents(boolean shouldNotify) {
+            this.notifyOnlyReliableEvents = shouldNotify;
+            return this;
+        }
+
 
         public ConnectionBuddyConfiguration build() {
             return new ConnectionBuddyConfiguration(this);

--- a/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/interfaces/NetworkRequestCheckListener.java
+++ b/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/interfaces/NetworkRequestCheckListener.java
@@ -1,0 +1,12 @@
+package com.zplesac.connectionbuddy.interfaces;
+
+/**
+ * Created by Željko Plesac on 09/03/16.
+ */
+public interface NetworkRequestCheckListener {
+
+    void onResponseObtained();
+
+    void onNoResponse();
+
+}

--- a/sampleapp/src/main/java/com/zplesac/connectionbuddy/sampleapp/activities/ManualConfigurationActivity.java
+++ b/sampleapp/src/main/java/com/zplesac/connectionbuddy/sampleapp/activities/ManualConfigurationActivity.java
@@ -4,12 +4,16 @@ package com.zplesac.connectionbuddy.sampleapp.activities;
 import com.zplesac.connectionbuddy.ConnectionBuddy;
 import com.zplesac.connectionbuddy.cache.ConnectionBuddyCache;
 import com.zplesac.connectionbuddy.interfaces.ConnectivityChangeListener;
+import com.zplesac.connectionbuddy.interfaces.NetworkRequestCheckListener;
 import com.zplesac.connectionbuddy.models.ConnectivityEvent;
 import com.zplesac.connectionbuddy.sampleapp.R;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 /**
  * Created by Željko Plesac on 08/09/15.
@@ -19,6 +23,8 @@ public class ManualConfigurationActivity extends Activity implements Connectivit
     private TextView tvTitle;
 
     private TextView tvConnectionType;
+
+    private Button buttonTestNetworkRequest;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -31,6 +37,10 @@ public class ManualConfigurationActivity extends Activity implements Connectivit
 
         tvTitle = (TextView) findViewById(R.id.tv_title);
         tvConnectionType = (TextView) findViewById(R.id.tv_connection_type);
+        buttonTestNetworkRequest = (Button) findViewById(R.id.button_test_network_request);
+
+        buttonTestNetworkRequest.setVisibility(View.VISIBLE);
+        buttonTestNetworkRequest.setOnClickListener(testNetworkRequestButtonClickListener);
     }
 
     @Override
@@ -52,4 +62,21 @@ public class ManualConfigurationActivity extends Activity implements Connectivit
         tvTitle.setText("Connection status: " + event.getState());
         tvConnectionType.setText("Connection type: " + event.getType());
     }
+
+    private View.OnClickListener testNetworkRequestButtonClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            ConnectionBuddy.getInstance().hasNetworkConnection(new NetworkRequestCheckListener() {
+                @Override
+                public void onResponseObtained() {
+                    Toast.makeText(ManualConfigurationActivity.this, "Response obtained!", Toast.LENGTH_LONG).show();
+                }
+
+                @Override
+                public void onNoResponse() {
+                    Toast.makeText(ManualConfigurationActivity.this, "No response obtained!", Toast.LENGTH_LONG).show();
+                }
+            });
+        }
+    };
 }

--- a/sampleapp/src/main/res/layout/activity_mvp.xml
+++ b/sampleapp/src/main/res/layout/activity_mvp.xml
@@ -14,4 +14,10 @@
             android:layout_marginTop="10dp"
             android:layout_width="wrap_content" android:layout_height="wrap_content"/>
 
+    <Button android:layout_width="wrap_content" android:layout_height="wrap_content"
+            android:id="@+id/button_test_network_request"
+            android:layout_marginTop="10dp"
+            android:visibility="gone"
+            android:text="Test network request"/>
+
 </LinearLayout>


### PR DESCRIPTION
Implemented option to perform test network request. This fixes #57.

Test network request is a hardcoded request to _http://clients3.google.com/generate_204_. If an empty 204 response is received, this means that user has active internet connection and that he is fully capable of performing network operations.

This feature can be used in 2 different ways:
- either manual test by using **_hasNetworkConnection(NetworkRequestCheckListener listener)_** method. If we received response, **_onResponseObtained()_** callback will be called, **_onNoResponse()_** otherwise
- either define in global configuration that we want to use reliable network events. By using this option, **_hasNetworkConnection(NetworkRequestCheckListener listener)_** method will automatically be called by ConnectionBuddy when device has active network connection
