### PR TITLE
Backported library to API level 8. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-24.0.0
-    - android-24
+    - build-tools-23.0.3
+    - android-23
     - extra-google-google_play_services
     - extra-google-m2repository
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.0.3
-    - android-23
+    - build-tools-24.0.0
+    - android-24
     - extra-google-google_play_services
     - extra-google-m2repository
     - extra-android-m2repository

--- a/connectionbuddy/build.gradle
+++ b/connectionbuddy/build.gradle
@@ -5,12 +5,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 24
+        targetSdkVersion 23
         versionCode 11
         versionName "1.1.2"
     }
@@ -22,7 +22,7 @@ android {
     }
 
     dependencies {
-        compile "com.android.support:support-v4:24.1.1"
+        compile "com.android.support:support-v4:23.2.1"
     }
 }
 

--- a/connectionbuddy/build.gradle
+++ b/connectionbuddy/build.gradle
@@ -5,12 +5,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.0"
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 23
+        minSdkVersion 8
+        targetSdkVersion 24
         versionCode 11
         versionName "1.1.2"
     }
@@ -19,6 +19,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    dependencies {
+        compile "com.android.support:support-v4:24.1.1"
     }
 }
 

--- a/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddyConfiguration.java
+++ b/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddyConfiguration.java
@@ -4,7 +4,7 @@ import com.zplesac.connectionbuddy.models.ConnectivityStrength;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
-import android.util.LruCache;
+import android.support.v4.util.LruCache;
 
 /**
  * Created by Željko Plesac on 09/10/15.

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -16,13 +16,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.neenbedankt.android-apt'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.0"
 
     defaultConfig {
         applicationId "com.zplesac.connectionbuddy.sampleapp"
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
     }
@@ -36,7 +36,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.3.0'
+    compile 'com.android.support:appcompat-v7:24.0.0'
     compile 'com.google.dagger:dagger:2.0'
     apt 'com.google.dagger:dagger-compiler:2.0'
     compile 'org.glassfish:javax.annotation:10.0-b28'

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -22,7 +22,7 @@ android {
     defaultConfig {
         applicationId "com.zplesac.connectionbuddy.sampleapp"
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.neenbedankt.android-apt'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.zplesac.connectionbuddy.sampleapp"
@@ -36,7 +36,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:appcompat-v7:23.2.1'
     compile 'com.google.dagger:dagger:2.0'
     apt 'com.google.dagger:dagger-compiler:2.0'
     compile 'org.glassfish:javax.annotation:10.0-b28'


### PR DESCRIPTION
Library minSdk lowered to API level 8. 

Using LruCache from support v4 library for Android versions lower than 12. Using Android LruCache caused crashes on API lower than 12 upon library initialization.
