### PR TITLE
Using Socket instead of HTTP connection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 

--- a/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddy.java
+++ b/connectionbuddy/src/main/java/com/zplesac/connectionbuddy/ConnectionBuddy.java
@@ -320,8 +320,8 @@ public class ConnectionBuddy {
     }
 
     /**
-     * Try to perform test network request to NETWORK_CHECK_URL. This way, we can determine if use is in fact capable of performing
-     * any network operations when he has active internet connection.
+     * Try to perform test network request to NETWORK_CHECK_URL_GOOGLE_DNS. The request is executed on a separate non-UI thread.
+     * This way, we can determine if use is in fact capable of performing any network operations when he has active internet connection.
      *
      * @param listener Callback listener.
      */

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -30,11 +30,11 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.dagger:dagger:2.0'
+    implementation 'com.google.dagger:dagger:2.28'
     implementation 'pub.devrel:easypermissions:0.2.1'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.0'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.28'
     implementation 'org.glassfish:javax.annotation:10.0-b28'
     implementation project(':connectionbuddy')
 }


### PR DESCRIPTION
- Dependencies have been updated and tested on the sample project

- testNetworkRequest refactored to use a Socket connection and ping Google DNS for faster internet connectivity test than the current implementation via an HTTPUrlConnection